### PR TITLE
Fix docker-compose SQL Server connection string

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,7 +5,7 @@ services:
   web:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
-      - ConnectionStrings__DefaultConnection=Server=127.0.0.1;Database=EventDB;User Id=sa;Password=Passw0rd!
+      - ConnectionStrings__DefaultConnection=Server=mssql;Database=EventDB;User Id=sa;Password=Passw0rd!
       - SuperAdmin__Email=asdf@email.com
       - SuperAdmin__Password=PaSsw0rd
     ports:


### PR DESCRIPTION
Refer to the database by service name.

More information here: https://docs.docker.com/docker-cloud/apps/service-links/#using-service-and-container-names-as-hostnames