### PR TITLE
Add alternate email implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -551,3 +551,4 @@ $RECYCLE.BIN/
 # End of https://www.gitignore.io/api/node,linux,macos,windows,aspnetcore,visualstudio,visualstudiocode
 
 Docs/Specification/Database-model.mwb.bak
+emails/

--- a/docs/Setup/Configuration.md
+++ b/docs/Setup/Configuration.md
@@ -1,0 +1,32 @@
+# Configuration
+
+The JSON structure defines the configuration for the application.
+
+```json
+{
+  "AppSettings": {
+    "EmailProvider": "SendGrid|File|Mock"
+  },
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=127.0.0.1,1401;Database=EventDb;User ID=sa;Password=pass"
+  },
+  "SendGrid": {
+    "EmailAddress": "hello@kursinord.no",
+    "Name": "Jane Doe",
+    "User": "asdf1234",
+    "Key": "asdf1234"
+  },
+  "SuperAdmin": {
+    "Email": "admin@email.com",
+    "Password": "Pa5sw0rd"
+  }
+}
+```
+
+While most of the configuration rests in the `appsettings.json` files, sensitive information like API keys and passwords can reside in environment variables instead using `__` or `:` as property qualifier. The dotnet usersecrets tool maybe used in place of environment variables during development.

--- a/src/EventManagement.Services/Messaging/FileEmailWriter.cs
+++ b/src/EventManagement.Services/Messaging/FileEmailWriter.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+
+namespace losol.EventManagement.Services.Messaging
+{
+	/// <summary>
+	/// Writes an email to a file instead of actually sending it.
+	/// This implementation is not designed to be used in production.
+	/// </summary>
+	public class FileEmailWriter : IEmailSender
+	{
+		private readonly IHostingEnvironment _environment;
+		private readonly string filePath;
+
+		public FileEmailWriter(IHostingEnvironment environment)
+		{
+			_environment = environment;
+			filePath = Path.Combine(_environment.ContentRootPath, "emails");
+			if(!Directory.Exists(filePath))
+			{
+				Directory.CreateDirectory(filePath);
+			}
+		}
+
+		public async Task SendEmailAsync(string email, string subject, string message)
+		{
+			// filename: {datetime}-{email}-{subject}.html
+			string filename = $"{DateTime.UtcNow.ToString("u")}-{email.GenerateSlug()}-{subject.GenerateSlug()}.html";
+
+			// Write the message to the file
+			using (StreamWriter outputFile = new StreamWriter(Path.Combine(filePath, filename)))
+			{
+				await outputFile.WriteLineAsync(message);
+			}
+		}
+	}
+
+	// Code borrowed from: https://stackoverflow.com/a/2921135
+	internal static class StringExtensions
+	{
+		internal static string GenerateSlug(this string phrase)
+		{
+			string str = phrase.RemoveAccent().ToLower();
+			// invalid chars           
+			str = Regex.Replace(str, @"[^a-z0-9\s-]", "");
+			// convert multiple spaces into one space   
+			str = Regex.Replace(str, @"\s+", " ").Trim();
+			// cut and trim 
+			str = str.Substring(0, str.Length <= 45 ? str.Length : 45).Trim();
+			str = Regex.Replace(str, @"\s", "-"); // hyphens   
+			return str;
+		}
+
+		// Not the best way to do it
+		// but it's only used on a dev environment,
+		// so leaving it as is.
+		internal static string RemoveAccent(this string txt)
+		{
+			byte[] bytes = System.Text.Encoding.GetEncoding("Cyrillic").GetBytes(txt);
+			return System.Text.Encoding.ASCII.GetString(bytes);
+		}
+	}
+}

--- a/src/EventManagement.Services/Messaging/MockEmailSender.cs
+++ b/src/EventManagement.Services/Messaging/MockEmailSender.cs
@@ -1,0 +1,12 @@
+﻿using System.Threading.Tasks;
+
+namespace losol.EventManagement.Services.Messaging
+{
+	public class MockEmailSender : IEmailSender
+	{
+		public async Task SendEmailAsync(string email, string subject, string message)
+		{
+			await Task.FromResult(0);
+		}
+	}
+}

--- a/src/EventManagement.Web/AppSettings.cs
+++ b/src/EventManagement.Web/AppSettings.cs
@@ -1,0 +1,14 @@
+﻿using System;
+namespace losol.EventManagement
+{
+	internal class AppSettings
+	{
+		public EmailProvider EmailProvider { get; set; }
+	}
+
+	internal enum EmailProvider 
+	{
+		SendGrid,
+		File
+	}
+}

--- a/src/EventManagement.Web/AppSettings.cs
+++ b/src/EventManagement.Web/AppSettings.cs
@@ -9,6 +9,7 @@ namespace losol.EventManagement
 	internal enum EmailProvider 
 	{
 		SendGrid,
-		File
+		File,
+		Mock
 	}
 }

--- a/src/EventManagement.Web/Startup.cs
+++ b/src/EventManagement.Web/Startup.cs
@@ -82,8 +82,6 @@ namespace losol.EventManagement
                 options.AddPolicy("AdministratorRole", policy => policy.RequireRole("Admin", "SuperAdmin"));
             });
             
-
-
             services.AddMvc()
                 .AddRazorPagesOptions(options =>
                 {
@@ -102,18 +100,28 @@ namespace losol.EventManagement
             {
                 case var env when env.IsProduction():
                     services.AddScoped<IDbInitializer, ProductionDbInitializer>();
-					services.Configure<SendGridOptions>(Configuration.GetSection("SendGrid"));
-					services.AddTransient<IEmailSender, SendGridEmailSender>();
                     break;
                 case var env when env.IsDevelopment():
                     services.AddScoped<IDbInitializer, DevelopmentDbInitializer>();
-					services.AddTransient<IEmailSender, FileEmailWriter>();
                     break;
                 default:
                     services.AddScoped<IDbInitializer, DefaultDbInitializer>();
-					services.AddTransient<IEmailSender, FileEmailWriter>();
                     break;
             }
+
+            var appsettings = Configuration.GetSection("AppSettings").Get<AppSettings>();
+
+			// Register the correct email provider depending on the config
+			switch(appsettings.EmailProvider)
+			{
+				case EmailProvider.SendGrid:
+					services.Configure<SendGridOptions>(Configuration.GetSection("SendGrid"));
+					services.AddTransient<IEmailSender, SendGridEmailSender>();
+					break;
+				case EmailProvider.File:
+					services.AddTransient<IEmailSender, FileEmailWriter>();
+					break;
+			}
 
 			// Register email services
 			services.AddTransient<StandardEmailSender>();

--- a/src/EventManagement.Web/Startup.cs
+++ b/src/EventManagement.Web/Startup.cs
@@ -121,6 +121,9 @@ namespace losol.EventManagement
 				case EmailProvider.File:
 					services.AddTransient<IEmailSender, FileEmailWriter>();
 					break;
+				case EmailProvider.Mock:
+					services.AddTransient<IEmailSender, MockEmailSender>();
+					break;
 			}
 
 			// Register email services

--- a/src/EventManagement.Web/appsettings.Development.json
+++ b/src/EventManagement.Web/appsettings.Development.json
@@ -1,4 +1,7 @@
 ﻿{
+  "AppSettings": {
+    "EmailProvider": "File"
+  },
   "Kestrel": {
     "EndPoints": {
       "Http": {

--- a/src/EventManagement.Web/appsettings.json
+++ b/src/EventManagement.Web/appsettings.json
@@ -1,11 +1,14 @@
 ﻿{
+  "AppSettings": {
+    "EmailProvider": "SendGrid"
+  },
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {
       "Default": "Warning"
     }
   },
-  "SendGrid":  {
+  "SendGrid": {
     "EmailAddress": "ikke-svar@nordland-legeforening.no",
     "Name": "Kursinord.no"
   }


### PR DESCRIPTION
This PR introduces two new email implementations:

1. `FileEmailWriter` - this writes the email to be sent to a file instead.
1. `MockEmailSender` - a placeholder email sender that does nothing.

An implementation can be selected by setting the `AppSettings.EmailProvider` field in `appsettings.json` (or the `AppSettings__EmailProvider` environment variable) to `SendGrid`, `File` or `Mock` and restarting the application.

This PR does not change the current behaviour in production.