### PR TITLE
Copy writeToPdf.js to output directory

### DIFF
--- a/src/EventManagement.Web/EventManagement.Web.csproj
+++ b/src/EventManagement.Web/EventManagement.Web.csproj
@@ -36,6 +36,11 @@
     <Folder Include="Views\Shared\Templates\Certificates\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="Node\writeToPdf.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Target Name="BuildWebAssets" BeforeTargets="Build">
     <Exec Command="npm install" />
     <Exec Command="gulp" />


### PR DESCRIPTION
The script file `Node/writeToPdf.js` is now copied to output directory.   
Tested using:

```bash
dotnet publish -o ./out src/EventManagement.Web/EventManagement.Web.csproj
```

Closes #80