### PR TITLE
Fix windows specific issues with certificate generation

### DIFF
--- a/src/EventManagement.Web/Controllers/CertificateController.cs
+++ b/src/EventManagement.Web/Controllers/CertificateController.cs
@@ -56,7 +56,7 @@ namespace EventManagement.Web.Controllers
                 return NotFound();
             }
             
-            string filename = $"{certificate.CertificateId}-{DateTime.Now.ToString("u")}.pdf";
+            string filename = $"{certificate.CertificateId}-{Guid.NewGuid().ToString()}.pdf";
             var result = await writer.Write(filename, CertificateVM.From(certificate));
             var bytes = await System.IO.File.ReadAllBytesAsync(writer.GetPathForFile(filename));
             return File(bytes, "application/pdf");

--- a/src/EventManagement.Web/Views/Shared/Templates/Certificates/CourseCertificate.with-google-fonts.cshtml
+++ b/src/EventManagement.Web/Views/Shared/Templates/Certificates/CourseCertificate.with-google-fonts.cshtml
@@ -7,11 +7,14 @@
   <head>
     <meta charset="utf8">
     <title>Certificate</title>
+    <link 
+      href="https://fonts.googleapis.com/css?family=Material+Icons|Reenie+Beanie|Carrois+Gothic+SC|Libre+Baskerville" 
+      rel="stylesheet" />
     <style>
       html, body {
         margin: 0;
         padding: 0;
-        font-family: 'Arial';
+        font-family: 'Carrois Gothic SC';
         font-weight: 500;
         font-size: 16px;
         background: rgb(241,241,241);
@@ -67,6 +70,7 @@
       }
       .handwriting {
         font-size: 48px;
+        font-family: 'Reenie Beanie';
         padding-bottom:0;
         text-decoration: underline;
       }
@@ -86,6 +90,7 @@
       }
 
       .text {
+        font-family: 'Libre Baskerville', serif;
         font-size: 14px
       }
 


### PR DESCRIPTION
* Use windows friendly filenames.
* Replace google fonts with Arial.

Closes #80
Related #55 