### PR TITLE
Use configuration for payment provider information

### DIFF
--- a/src/EventManagement.Domain/Order.cs
+++ b/src/EventManagement.Domain/Order.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using static losol.EventManagement.Domain.PaymentMethod;
 
 namespace losol.EventManagement.Domain
 {
@@ -78,6 +79,7 @@ namespace losol.EventManagement.Domain
 		public string CustomerVatNumber { get; set; }
 		public string CustomerInvoiceReference { get; set; }
 		public int? PaymentMethodId { get; set; }
+        public PaymentProvider? PaymentMethod { get; set; }
 
 		public DateTime OrderTime { get; set; } = DateTime.UtcNow;
 
@@ -89,7 +91,6 @@ namespace losol.EventManagement.Domain
 
 		// Navigational properties
 		public Registration Registration { get; set; }
-		public PaymentMethod PaymentMethod { get; set; }
 		public ApplicationUser User { get; set; }
 		public List<OrderLine> OrderLines { get; set; }
 

--- a/src/EventManagement.Domain/PaymentMethod.cs
+++ b/src/EventManagement.Domain/PaymentMethod.cs
@@ -6,29 +6,24 @@ using System.Threading.Tasks;
 
 namespace losol.EventManagement.Domain
 {
-	public class PaymentMethod
-	{
-		public enum PaymentProvider
-		{
-			EmailInvoice,
-			Stripe,
-			PowerOfficeEmailInvoice,
-			PowerOfficeEHFInvoice,
-			Vipps
-		}
+    public class PaymentMethod
+    {
+        public enum PaymentProvider
+        {
+            EmailInvoice,
+            Stripe,
+            PowerOfficeEmailInvoice,
+            PowerOfficeEHFInvoice,
+            Vipps
+        }
 
-		public int PaymentMethodId { get; set; }
+        public int PaymentMethodId { get; set; }
 
-		public string Code { get; set; }
+        public string Name { get; set; }
+        public PaymentProvider Provider { get; set; }
 
-		[Required]
-		[StringLength(75)]
-		[Display(Name = "Navn på betalingsmetode")]
-		public string Name { get; set; }
-		public PaymentProvider Provider { get; set; }
-
-		public bool Active { get; set; } = false;
-		public bool AdminOnly { get; set; } = false;
-		public bool IsDefault { get; set; } = false;
-	}
+        public bool Active { get; set; } = false;
+        public bool AdminOnly { get; set; } = false;
+        public bool IsDefault { get; set; } = false;
+    }
 }

--- a/src/EventManagement.Domain/Registration.cs
+++ b/src/EventManagement.Domain/Registration.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
 using static losol.EventManagement.Domain.Order;
+using static losol.EventManagement.Domain.PaymentMethod;
 
 namespace losol.EventManagement.Domain
 {
@@ -67,7 +68,8 @@ namespace losol.EventManagement.Domain
 		public bool FreeRegistration { get; set; } = false;
 
 		[Display(Name = "Betalingsmetode")]
-		public int? PaymentMethodId { get; set; }
+		public PaymentProvider? PaymentMethod { get; set; }
+        public int? PaymentMethodId { get; set; }
 
 		[Display(Name = "Verifisert påmelding?")]
 		public bool Verified { get; set; } = false;
@@ -81,7 +83,7 @@ namespace losol.EventManagement.Domain
 		// Navigation properties
 		public EventInfo EventInfo { get; set; }
 		public ApplicationUser User { get; set; }
-		public PaymentMethod PaymentMethod { get; set; }
+		// public PaymentMethod PaymentMethod { get; set; }
 		public List<Order> Orders { get; set; }
 
 		public void Verify()
@@ -150,7 +152,7 @@ namespace losol.EventManagement.Domain
 				CustomerVatNumber = CustomerVatNumber,
 				CustomerInvoiceReference = CustomerInvoiceReference,
 
-				PaymentMethodId = PaymentMethodId,
+				PaymentMethod = PaymentMethod,
 				RegistrationId = RegistrationId
 			};
 

--- a/src/EventManagement.Infrastructure/Migrations/20180514041901_AddPaymentMethodField.Designer.cs
+++ b/src/EventManagement.Infrastructure/Migrations/20180514041901_AddPaymentMethodField.Designer.cs
@@ -12,9 +12,10 @@ using System;
 namespace losol.EventManagement.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20180514041901_AddPaymentMethodField")]
+    partial class AddPaymentMethodField
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/EventManagement.Infrastructure/Migrations/20180514041901_AddPaymentMethodField.cs
+++ b/src/EventManagement.Infrastructure/Migrations/20180514041901_AddPaymentMethodField.cs
@@ -1,0 +1,99 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+using System.Collections.Generic;
+
+namespace losol.EventManagement.Infrastructure.Migrations
+{
+    public partial class AddPaymentMethodField : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Orders_PaymentMethods_PaymentMethodId",
+                table: "Orders");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Registrations_PaymentMethods_PaymentMethodId",
+                table: "Registrations");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Registrations_PaymentMethodId",
+                table: "Registrations");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Orders_PaymentMethodId",
+                table: "Orders");
+
+            migrationBuilder.DropColumn(
+                name: "Code",
+                table: "PaymentMethods");
+
+            migrationBuilder.AddColumn<int>(
+                name: "PaymentMethod",
+                table: "Registrations",
+                nullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "PaymentMethods",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldMaxLength: 75);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PaymentMethod",
+                table: "Orders",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PaymentMethod",
+                table: "Registrations");
+
+            migrationBuilder.DropColumn(
+                name: "PaymentMethod",
+                table: "Orders");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "PaymentMethods",
+                maxLength: 75,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Code",
+                table: "PaymentMethods",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Registrations_PaymentMethodId",
+                table: "Registrations",
+                column: "PaymentMethodId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Orders_PaymentMethodId",
+                table: "Orders",
+                column: "PaymentMethodId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Orders_PaymentMethods_PaymentMethodId",
+                table: "Orders",
+                column: "PaymentMethodId",
+                principalTable: "PaymentMethods",
+                principalColumn: "PaymentMethodId",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Registrations_PaymentMethods_PaymentMethodId",
+                table: "Registrations",
+                column: "PaymentMethodId",
+                principalTable: "PaymentMethods",
+                principalColumn: "PaymentMethodId",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/src/EventManagement.Services/DbInitializers/BaseDbInitializer.cs
+++ b/src/EventManagement.Services/DbInitializers/BaseDbInitializer.cs
@@ -16,9 +16,9 @@ namespace losol.EventManagement.Services.DbInitializers
 		private readonly UserManager<ApplicationUser> _userManager;
 		private readonly DbInitializerOptions _config;
 
-		public BaseDbInitializer(ApplicationDbContext db, 
-		                         RoleManager<IdentityRole> roleManager,  
-		                         UserManager<ApplicationUser> userManager, 
+		public BaseDbInitializer(ApplicationDbContext db,
+		                         RoleManager<IdentityRole> roleManager,
+		                         UserManager<ApplicationUser> userManager,
 		                         IOptions<DbInitializerOptions> config)
 		{
 			_db = db;
@@ -67,24 +67,7 @@ namespace losol.EventManagement.Services.DbInitializers
 
 			}
 
-			// Seed payment methods
-			if (!_db.PaymentMethods.Any())
-			{
-				var paymentMethods = new PaymentMethod[] {
-					new PaymentMethod {Code="Card", Name="Kortbetaling", Active=false},
-					new PaymentMethod {Code="Email_invoice", Name="E-postfaktura", Active=true},
-					new PaymentMethod {Code="EHF_invoice", Name="EHF-faktura", Active=true}
-				};
-
-				foreach (var item in paymentMethods)
-				{
-					await _db.PaymentMethods.AddAsync(item);
-				}
-
-				await _db.SaveChangesAsync();
-			}
-
-			// Seed test events if no events exist. 
+			// Seed test events if no events exist.
 			if (!_db.EventInfos.Any())
 			{
 				var eventInfos = new EventInfo[]

--- a/src/EventManagement.Services/IPaymentMethodService.cs
+++ b/src/EventManagement.Services/IPaymentMethodService.cs
@@ -7,9 +7,9 @@ namespace losol.EventManagement.Services
 {
 	public interface IPaymentMethodService
 	{
-		Task<PaymentMethod> GetAsync(int id);
-		Task<List<PaymentMethod>> GetActivePaymentMethodsAsync();
+		PaymentMethod Get(int id);
+		List<PaymentMethod> GetActivePaymentMethods();
 		int GetDefaultPaymentMethodId();
-		Task<PaymentMethod> GetDefaultPaymentMethod();
+		PaymentMethod GetDefaultPaymentMethod();
 	}
 }

--- a/src/EventManagement.Services/IPaymentMethodService.cs
+++ b/src/EventManagement.Services/IPaymentMethodService.cs
@@ -2,14 +2,15 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using losol.EventManagement.Domain;
+using static losol.EventManagement.Domain.PaymentMethod;
 
 namespace losol.EventManagement.Services
 {
 	public interface IPaymentMethodService
 	{
 		PaymentMethod Get(int id);
+        PaymentMethod Get(PaymentProvider provider);
 		List<PaymentMethod> GetActivePaymentMethods();
-		int GetDefaultPaymentMethodId();
 		PaymentMethod GetDefaultPaymentMethod();
 	}
 }

--- a/src/EventManagement.Services/IRegistrationService.cs
+++ b/src/EventManagement.Services/IRegistrationService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using losol.EventManagement.Domain;
+using static losol.EventManagement.Domain.PaymentMethod;
 
 namespace losol.EventManagement.Services
 {
@@ -15,7 +16,7 @@ namespace losol.EventManagement.Services
 		Task<List<Registration>> GetRegistrations(int eventId);
 		Task<List<Registration>> GetRegistrationsWithOrders(int eventId);
 		Task<List<Registration>> GetRegistrationsWithOrders(ApplicationUser user);
-		
+
 		Task<int> CreateRegistration(Registration registration);
 		Task<int> CreateRegistration (Registration registration, List<OrderVM> ordersVm);
 		[Obsolete]
@@ -25,7 +26,7 @@ namespace losol.EventManagement.Services
 
 		Task<bool> UpdateParticipantInfo(int registrationId, string name, string JobTitle, string city, string Employer);
 		Task<bool> UpdateCustomerInfo(int registrationId, string customerName, string customerEmail, string customerVatNumber, string customerInvoiceReference);
-		Task<bool> UpdatePaymentMethod(int registrationId, int paymentMethodId);
+		Task<bool> UpdatePaymentMethod(int registrationId, PaymentProvider provider);
 		Task<bool> UpdateRegistrationStatus(int registrationId, Registration.RegistrationStatus registrationStatus);
 
 		Task<bool> UpdateRegistrationType(int registrationId, Registration.RegistrationType registrationType);

--- a/src/EventManagement.Services/OrderService.cs
+++ b/src/EventManagement.Services/OrderService.cs
@@ -125,7 +125,7 @@ namespace losol.EventManagement.Services {
 
 			line.Quantity = quantity;
 			line.Price = price;
-			
+
 			line.ProductVariantId = variantId;
 			if(variantId != null)
 			{
@@ -200,7 +200,7 @@ namespace losol.EventManagement.Services {
 
 			var newOrder = new Order
 			{
-				PaymentMethodId = order.PaymentMethodId,
+				PaymentMethod = order.PaymentMethod,
 				RegistrationId = order.RegistrationId,
 				Comments = order.Comments,
 				CustomerEmail = order.CustomerEmail,
@@ -221,7 +221,7 @@ namespace losol.EventManagement.Services {
 			{
 				throw new InvalidOperationException("Cannot recreate order because some of the products were already ordered.");
 			}
-			
+
 			await _db.AddAsync(newOrder);
 			await _db.SaveChangesAsync();
 			return newOrder;

--- a/src/EventManagement.Services/OrderService.cs
+++ b/src/EventManagement.Services/OrderService.cs
@@ -46,7 +46,6 @@ namespace losol.EventManagement.Services {
 			.Include (o => o.User)
 			.Include (o => o.Registration)
 			.ThenInclude (r => r.EventInfo)
-			.Include (o => o.PaymentMethod)
 			.SingleOrDefaultAsync ();
 
 		public Task<List<Order>> GetOrdersForEventAsync (int eventId) =>
@@ -179,7 +178,6 @@ namespace losol.EventManagement.Services {
 				.Include (o => o.User)
 				.Include (o => o.Registration)
 				.ThenInclude (r => r.EventInfo)
-				.Include (o => o.PaymentMethod)
 				.SingleOrDefaultAsync (o => o.OrderId == orderId);
 			await _powerOfficeService.CreateInvoiceAsync (order);
 

--- a/src/EventManagement.Services/PaymentMethodService.cs
+++ b/src/EventManagement.Services/PaymentMethodService.cs
@@ -4,40 +4,37 @@ using System.Threading.Tasks;
 using losol.EventManagement.Domain;
 using losol.EventManagement.Infrastructure;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace losol.EventManagement.Services
 {
 	public class PaymentMethodService : IPaymentMethodService
 	{
-		private readonly ApplicationDbContext _db;
+        private readonly IEnumerable<PaymentMethod> paymentMethods;
 
-		public PaymentMethodService(ApplicationDbContext db)
+		public PaymentMethodService(IOptions<List<PaymentMethod>> paymentMethodConfig)
 		{
-			_db = db;
+            paymentMethods = paymentMethodConfig.Value;
 		}
 
-		public Task<List<PaymentMethod>> GetActivePaymentMethodsAsync()
+		public List<PaymentMethod> GetActivePaymentMethods()
 		{
-			return _db.PaymentMethods
-				      .Where(pm => pm.Active)
-				      .AsNoTracking()
-				      .ToListAsync();
+			return paymentMethods.Where(p => p.Active).ToList();
 		}
 
-		public Task<PaymentMethod> GetAsync(int id)
+		public PaymentMethod Get(int id)
 		{
-			return _db.PaymentMethods.FindAsync(id);
+			return paymentMethods.SingleOrDefault(p => p.PaymentMethodId == id);
 		}
 
-		public Task<PaymentMethod> GetDefaultPaymentMethod()
+		public PaymentMethod GetDefaultPaymentMethod()
 		{
-			return GetAsync(GetDefaultPaymentMethodId());
+			return paymentMethods.Single(p => p.IsDefault);
 		}
 
 		public int GetDefaultPaymentMethodId()
 		{
-			// HACK: Read this from a config!
-			return 2;
+			return GetDefaultPaymentMethod().PaymentMethodId;
 		}
 	}
 }

--- a/src/EventManagement.Services/PaymentMethodService.cs
+++ b/src/EventManagement.Services/PaymentMethodService.cs
@@ -5,6 +5,7 @@ using losol.EventManagement.Domain;
 using losol.EventManagement.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
+using static losol.EventManagement.Domain.PaymentMethod;
 
 namespace losol.EventManagement.Services
 {
@@ -27,14 +28,14 @@ namespace losol.EventManagement.Services
 			return paymentMethods.SingleOrDefault(p => p.PaymentMethodId == id);
 		}
 
+        public PaymentMethod Get(PaymentProvider provider)
+		{
+			return paymentMethods.SingleOrDefault(p => p.Provider == provider);
+		}
+
 		public PaymentMethod GetDefaultPaymentMethod()
 		{
 			return paymentMethods.Single(p => p.IsDefault);
-		}
-
-		public int GetDefaultPaymentMethodId()
-		{
-			return GetDefaultPaymentMethod().PaymentMethodId;
 		}
 	}
 }

--- a/src/EventManagement.Services/PowerOffice/PowerOfficeService.cs
+++ b/src/EventManagement.Services/PowerOffice/PowerOfficeService.cs
@@ -10,6 +10,7 @@ using GoApi.Party;
 using losol.EventManagement.Domain;
 using losol.EventManagement.Infrastructure;
 using Microsoft.Extensions.Options;
+using static losol.EventManagement.Domain.PaymentMethod;
 
 namespace losol.EventManagement.Services.PowerOffice {
     public class PowerOfficeService : IInvoicingService {
@@ -32,9 +33,9 @@ namespace losol.EventManagement.Services.PowerOffice {
         public async Task CreateInvoiceAsync (Order order) {
             var customer = await createCustomerIfNotExists (order);
             await createProductsIfNotExists (order);
-            
+
             var invoice = new OutgoingInvoice {
-                Status = OutgoingInvoiceStatus.Draft, 
+                Status = OutgoingInvoiceStatus.Draft,
                 OrderDate = order.OrderTime,
                 CustomerReference = order.CustomerInvoiceReference,
                 CustomerCode = customer.Code,
@@ -92,7 +93,7 @@ namespace losol.EventManagement.Services.PowerOffice {
             }
 
             // If not, create the customer
-          
+
             var customer = new Customer {
                 EmailAddress = customerEmail,
                 Name = order.CustomerName ?? order.User.Name,
@@ -100,9 +101,9 @@ namespace losol.EventManagement.Services.PowerOffice {
                 InvoiceEmailAddress = customerEmail
             };
 
-            if (order.PaymentMethod.Name == "EHF" && string.IsNullOrWhiteSpace (order.CustomerVatNumber)) {
+            if (order.PaymentMethod == PaymentProvider.PowerOfficeEHFInvoice && string.IsNullOrWhiteSpace (order.CustomerVatNumber)) {
                 customer.InvoiceDeliveryType = InvoiceDeliveryType.EHF;
-            } 
+            }
             else {
                 customer.InvoiceDeliveryType = InvoiceDeliveryType.PdfByEmail;
             }

--- a/src/EventManagement.Services/PowerOffice/PowerOfficeService.cs
+++ b/src/EventManagement.Services/PowerOffice/PowerOfficeService.cs
@@ -101,7 +101,7 @@ namespace losol.EventManagement.Services.PowerOffice {
                 InvoiceEmailAddress = customerEmail
             };
 
-            if (order.PaymentMethod == PaymentProvider.PowerOfficeEHFInvoice && string.IsNullOrWhiteSpace (order.CustomerVatNumber)) {
+            if (order.PaymentMethod == PaymentProvider.PowerOfficeEHFInvoice && !string.IsNullOrWhiteSpace (order.CustomerVatNumber)) {
                 customer.InvoiceDeliveryType = InvoiceDeliveryType.EHF;
             }
             else {

--- a/src/EventManagement.Web/Controllers/Api/RegistrationsController.cs
+++ b/src/EventManagement.Web/Controllers/Api/RegistrationsController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 using static losol.EventManagement.Domain.Registration;
 using System.Collections.Generic;
 using System.Linq;
+using static losol.EventManagement.Domain.PaymentMethod;
 
 namespace losol.EventManagement.Web.Controllers.Api {
     [Authorize (Policy = "AdministratorRole")]
@@ -31,7 +32,7 @@ namespace losol.EventManagement.Web.Controllers.Api {
                     vm.ParticipantJobTitle,
                     vm.ParticipantCity,
                     vm.ParticipantEmployer);
-            } 
+            }
             catch (ArgumentException) {
                 return BadRequest ();
             }
@@ -48,21 +49,21 @@ namespace losol.EventManagement.Web.Controllers.Api {
                     vm.CustomerEmail,
                     vm.CustomerVatNumber,
                     vm.CustomerInvoiceReference);
-            } 
+            }
             catch (ArgumentException) {
                 return BadRequest ();
             }
             return Ok ();
         }
 
-        [HttpPost ("{id}/paymentmethod/update/{paymentmethodId}")]
-        public async Task<ActionResult> SetPaymentMethod ([FromRoute] int id, [FromRoute] int paymentmethodId) {
+        [HttpPost ("{id}/paymentmethod/update/{paymentmethod}")]
+        public async Task<ActionResult> SetPaymentMethod ([FromRoute] int id, [FromRoute] PaymentProvider paymentmethod) {
             if (!ModelState.IsValid) return BadRequest ();
             try {
                 await _registrationsService.UpdatePaymentMethod (
                     id,
-                    paymentmethodId);
-            } 
+                    paymentmethod);
+            }
             catch (ArgumentException) {
                 return BadRequest ();
             }
@@ -88,7 +89,7 @@ namespace losol.EventManagement.Web.Controllers.Api {
                 return BadRequest ();
             }
         }
-        
+
         [HttpPost ("type/update/{id}/{type}")]
         public async Task<ActionResult> UpdateRegistrationType ([FromRoute] int id, [FromRoute] RegistrationType type) {
             try {

--- a/src/EventManagement.Web/Pages/Admin/Events/AddRegistration.cshtml
+++ b/src/EventManagement.Web/Pages/Admin/Events/AddRegistration.cshtml
@@ -1,6 +1,7 @@
 @page "{id:int}"
 @model losol.EventManagement.Pages.Admin.Events.AddRegistrationModel
 @using static losol.EventManagement.Domain.Registration;
+@using static losol.EventManagement.Domain.PaymentMethod;
 @{
     ViewData["Title"] = "Legg til deltaker på arrangement";
     var RegistrationTypes = (RegistrationType[])Enum.GetValues(typeof(RegistrationType));
@@ -16,7 +17,7 @@
 
     <form method="post" id="form-add-registration">
         <div class="row justify-content-between py-3">
-            <div class="col-md-9"> 
+            <div class="col-md-9">
                 <div class="form-group">
                     <label>Bruker</label>
                     @Html.Partial("Partials/_UserSelect")
@@ -31,7 +32,7 @@
                         <label class="form-check-label">
                             <input asp-for="Registration.Type"
                                 class="form-check-input" type="radio" value="@type">
-                            
+
                                 @type
                             </label>
                         </div>
@@ -41,16 +42,16 @@
 
                 @* START PAYMENT  *@
                 @if (Model.EventInfo.Products.Any()) {
-                <div id="payment py-5" > 
+                <div id="payment py-5" >
                     <div class="form-group"><!-- Payment method -->
-                        <label asp-for="Registration.PaymentMethodId"></label><br>
+                        <label asp-for="Registration.PaymentMethod"></label><br>
                         <div>
                         @foreach (var item in Model.PaymentMethods)
                         {
-                            <label class="radio-inline pr-3">  
-                            <input asp-for="Registration.PaymentMethodId" id="Registration_PaymentMethodId_@item.PaymentMethodId" type="radio" value="@item.PaymentMethodId" onclick="paymentMethod()"/> @item.Name  
+                            <label class="radio-inline pr-3">
+                            <input asp-for="Registration.PaymentMethod" id="Registration_PaymentMethod_@item.Provider" type="radio" value="@item.Provider" onclick="paymentMethod()"/> @item.Name
                             </label>
-                    
+
                         }
                         </div>
                     </div>
@@ -93,19 +94,19 @@
     </form>
 
     </div>
-    
+
     @section Scripts {
         @Html.Partial("_ValidationScriptsPartial");
         @Html.Partial("Partials/_UserSelectScript");
         <script>
             function paymentMethod() {
-                if (document.getElementById('Registration_PaymentMethodId_3').checked) {
+                if (document.getElementById('Registration_PaymentMethod_@PaymentProvider.PowerOfficeEHFInvoice').checked) {
                     $('#customerdetails').collapse('show');
-                };   
+                };
             }
             $('#form-add-registration').on('submit', function(){
                 $('#user-id').val($('#input-user').typeahead('getActive').id);
             })
         </script>
-    }    
+    }
 </div>

--- a/src/EventManagement.Web/Pages/Admin/Events/AddRegistration.cshtml.cs
+++ b/src/EventManagement.Web/Pages/Admin/Events/AddRegistration.cshtml.cs
@@ -8,6 +8,7 @@ using losol.EventManagement.Domain;
 using losol.EventManagement.Services;
 using Microsoft.AspNetCore.Identity;
 using Mapster;
+using static losol.EventManagement.Domain.PaymentMethod;
 
 namespace losol.EventManagement.Pages.Admin.Events
 {
@@ -35,7 +36,7 @@ namespace losol.EventManagement.Pages.Admin.Events
 		public EventInfo EventInfo { get; set; }
 		public List<PaymentMethod> PaymentMethods { get; set; }
 		public List<Product> Products => EventInfo.Products;
-		public int DefaultPaymentMethod => _paymentMethodService.GetDefaultPaymentMethodId();
+		public PaymentProvider DefaultPaymentMethod => _paymentMethodService.GetDefaultPaymentMethod().Provider;
 
         public async Task<IActionResult> OnGetAsync(int id)
         {

--- a/src/EventManagement.Web/Pages/Admin/Events/AddRegistration.cshtml.cs
+++ b/src/EventManagement.Web/Pages/Admin/Events/AddRegistration.cshtml.cs
@@ -18,7 +18,7 @@ namespace losol.EventManagement.Pages.Admin.Events
         private readonly IOrderService _orders;
         private readonly IPaymentMethodService _paymentMethodService;
 		private readonly UserManager<ApplicationUser> _userManager;
-        
+
 
         public AddRegistrationModel(IOrderService orders, IEventInfoService eventInfos, IRegistrationService registrations, IPaymentMethodService paymentMethods, UserManager<ApplicationUser> userManager)
         {
@@ -41,8 +41,8 @@ namespace losol.EventManagement.Pages.Admin.Events
         {
 			EventInfo = EventInfo ?? await _eventsService.GetWithProductsAsync(id);
 			if (EventInfo == null) return NotFound();
-            
-            PaymentMethods = await _paymentMethodService.GetActivePaymentMethodsAsync();
+
+            PaymentMethods = _paymentMethodService.GetActivePaymentMethods();
 			Registration = new Web.Pages.Events.Register.RegisterVM(EventInfo, DefaultPaymentMethod);
 
             return Page();

--- a/src/EventManagement.Web/Pages/Admin/Orders/Details.cshtml
+++ b/src/EventManagement.Web/Pages/Admin/Orders/Details.cshtml
@@ -10,12 +10,12 @@
                            .Select(x => new { id = x.ProductVariantId, pid = x.ProductId, name = x.Name });
 }
 <div class="bg-gray-300 py-3">
-    <div class="container"> 
+    <div class="container">
         <h2>
             Ordre #@order.OrderId - @order.Registration.EventInfo.Title
             <order-status value="@order.Status" />
         </h2>
-        <div class="d-print-none"> 
+        <div class="d-print-none">
         @if(order.Status != Order.OrderStatus.Cancelled)
         {
             <div class="btn-group " role="group">
@@ -35,7 +35,7 @@
                 </div>
             </div>
             }
-            else 
+            else
             {
                 <button type="button" class="btn btn-primary " onclick="reopenOrder()">
                     Reopen
@@ -43,15 +43,15 @@
             }
             @if(order.Status != Order.OrderStatus.Invoiced)
             {
-                <button class="btn btn-small btn-secondary" data-toggle="popover" 
-                    data-trigger="focus" 
-                    title="Make order free?" 
+                <button class="btn btn-small btn-secondary" data-toggle="popover"
+                    data-trigger="focus"
+                    title="Make order free?"
                     data-content="<button class='btn btn-sm btn-danger' onclick='makeFree()'>Yes</button><button class='btn btn-sm btn-success'>No</button>">Make Free</button>
             }
         </div>
     </div>
 </div>
-<div class="container py-3"> 
+<div class="container py-3">
         <div class="row justify-content-between">
             <div class="card col-md-5 m-2">
                 <div class="card-body">
@@ -67,12 +67,12 @@
                 </dl>
                 </div>
             </div>
-            
+
             <div class="card col-md-5 m-2">
                 <div class="card-body">
                     <h4 class="card-title">Betalingsinformasjon</h4>
                     <hr />
-                    <dl class=""> 
+                    <dl class="">
                         <dt class="">Kundenavn</dt>
                         <dd class="">@order.CustomerName &nbsp;</dd>
                         <dt class="">Epost for faktura</dt>
@@ -82,7 +82,7 @@
                         <dt class="">Fakturareferanse</dt>
                         <dd class="">@order.CustomerInvoiceReference &nbsp;</dd>
                         <dt class="">Betalingsmetode</dt>
-                        <dd class=""> @order.PaymentMethod?.Name</dd>
+                        <dd class=""> @order.PaymentMethod</dd>
                
                     </dl>
 
@@ -91,13 +91,13 @@
                 </div>
             </div>
         </div>
-            
+
             <h2>
-                Ordrelinjer 
+                Ordrelinjer
                 @if(order.CanEdit)
                 {
-                    <button class="ml-3 btn btn-success d-print-none" 
-                        data-toggle="modal" 
+                    <button class="ml-3 btn btn-success d-print-none"
+                        data-toggle="modal"
                         data-target="#add-orderline-modal">Ny ordrelinje</button>
                 }
             </h2>
@@ -131,9 +131,9 @@
                             @if(order.CanEdit)
                             {
                                 <td class="d-print-none">
-                                    <a tabindex="0" 
-                                        class="btn btn-sm btn-primary btn-edit-line" 
-                                        role="button"    
+                                    <a tabindex="0"
+                                        class="btn btn-sm btn-primary btn-edit-line"
+                                        role="button"
                                         data-quantity="@line.Quantity"
                                         data-id="@line.OrderLineId"
                                         data-product-id="@line.ProductId"
@@ -141,10 +141,10 @@
                                         data-trigger="focus">
                                         <i class="material-icons md-light md-18">edit</i>
                                     </a>
-                                    <a tabindex="0" class="btn btn-sm btn-danger" role="button"       
-                                        data-toggle="popover" 
-                                        data-trigger="focus" 
-                                        title="Delete line?" 
+                                    <a tabindex="0" class="btn btn-sm btn-danger" role="button"
+                                        data-toggle="popover"
+                                        data-trigger="focus"
+                                        title="Delete line?"
                                         data-content="<button class='btn btn-sm btn-danger btn-delete-line' onclick='deleteOrderLine(@line.OrderLineId)'>Yes</button><button class='btn btn-sm btn-success'>No</button>">
                                         <i class="material-icons md-light md-18">delete</i>
                                     </a>
@@ -180,12 +180,12 @@
 
 
 <!-- Add OrderLine Modal -->
-<div class="modal fade" 
-    id="add-orderline-modal" 
-    tabindex="-1" 
-    role="dialog" 
+<div class="modal fade"
+    id="add-orderline-modal"
+    tabindex="-1"
+    role="dialog"
     data-keyboard="false"
-    aria-labelledby="add-orderline-modal-title" 
+    aria-labelledby="add-orderline-modal-title"
     aria-hidden="true">
     <div class="modal-dialog" role="document">
     <div class="modal-content">
@@ -199,8 +199,8 @@
         <div class="form-group">
             <label class="control-label">Product</label>
             <select id="selected-product" class="form-control">
-                <option selected disabled>Select Product</option>   
-                @foreach(var p in products) 
+                <option selected disabled>Select Product</option>
+                @foreach(var p in products)
                 {
                     <option value="@p.ProductId">@p.Name</option>
                 }
@@ -221,12 +221,12 @@
 </div>
 
 <!-- Edit OrderLine Modal -->
-<div class="modal fade" 
-    id="edit-orderline-modal" 
-    tabindex="-1" 
-    role="dialog" 
+<div class="modal fade"
+    id="edit-orderline-modal"
+    tabindex="-1"
+    role="dialog"
     data-keyboard="false"
-    aria-labelledby="edit-orderline-modal-title" 
+    aria-labelledby="edit-orderline-modal-title"
     aria-hidden="true">
     <div class="modal-dialog" role="document">
     <div class="modal-content">
@@ -260,12 +260,12 @@
 </div>
 
 <!-- Edit Order (customer/comments) Modal -->
-<div class="modal fade" 
-    id="edit-order-modal" 
-    tabindex="-1" 
-    role="dialog" 
+<div class="modal fade"
+    id="edit-order-modal"
+    tabindex="-1"
+    role="dialog"
     data-keyboard="false"
-    aria-labelledby="edit-order-modal-title" 
+    aria-labelledby="edit-order-modal-title"
     aria-hidden="true">
     <div class="modal-dialog" role="document">
     <div class="modal-content">
@@ -306,7 +306,7 @@
 TODO: Gotta do it in a better way later. *@
 <div id="input-disabler" style="position: fixed; top: 0; left: 0; bottom: 0; right: 0; color: transparent; z-index:2000; display: none"></div>
 
-@section scripts { 
+@section scripts {
     <script>
 
         $(function () {
@@ -338,7 +338,7 @@ TODO: Gotta do it in a better way later. *@
                     $sVariants.prop('disabled', true);
                 }
             });
-            
+
             const $disabler = $('#input-disabler');
             const $spinner = $('.fa-spinner');
             $('#btn-add-orderline').bind('click', function() {
@@ -364,7 +364,7 @@ TODO: Gotta do it in a better way later. *@
             $('.btn-edit-line').on('click', function() {
                 const editId = $(this).data('id');
                 const productId = $(this).data('product-id');
-                
+
                 const $editModal = $('#edit-orderline-modal');
                 const $inputVariants = $('#input-edit-variant');
                 const $inputQuantity = $('#input-edit-quantity');
@@ -439,7 +439,7 @@ TODO: Gotta do it in a better way later. *@
             toastr.info('Please wait.', null, { timeOut: 0 });
             $.post('/api/v0/orders/update/@id/' + status, function() {
                 location.reload();
-            })            
+            })
         }
 
         function deleteOrder() {
@@ -465,5 +465,5 @@ TODO: Gotta do it in a better way later. *@
             })
         }
     </script>
-    
+
 }

--- a/src/EventManagement.Web/Pages/Admin/Registrations/Create.cshtml
+++ b/src/EventManagement.Web/Pages/Admin/Registrations/Create.cshtml
@@ -96,8 +96,8 @@
                 </div>
             </div>
             <div class="form-group">
-                <label asp-for="Registration.PaymentMethodId" class="control-label"></label>
-                <select asp-for="Registration.PaymentMethodId" class ="form-control" asp-items="ViewBag.PaymentMethodId"></select>
+                <label asp-for="Registration.PaymentMethod" class="control-label"></label>
+                <select asp-for="Registration.PaymentMethod" class ="form-control" asp-items="ViewBag.PaymentMethod"></select>
             </div>
             <div class="form-group">
                 <div class="checkbox">

--- a/src/EventManagement.Web/Pages/Admin/Registrations/Create.cshtml.cs
+++ b/src/EventManagement.Web/Pages/Admin/Registrations/Create.cshtml.cs
@@ -7,22 +7,25 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using losol.EventManagement.Domain;
 using losol.EventManagement.Infrastructure;
+using losol.EventManagement.Services;
 
 namespace losol.EventManagement.Pages.Admin.Registrations
 {
     public class CreateModel : PageModel
     {
         private readonly ApplicationDbContext _context;
+        private readonly IPaymentMethodService _paymentMethods;
 
-        public CreateModel(ApplicationDbContext context)
+        public CreateModel(ApplicationDbContext context, IPaymentMethodService paymentMethods)
         {
             _context = context;
+            _paymentMethods = paymentMethods;
         }
 
         public IActionResult OnGet()
         {
         ViewData["EventInfoId"] = new SelectList(_context.EventInfos, "EventInfoId", "Code");
-        ViewData["PaymentMethodId"] = new SelectList(_context.PaymentMethods, "PaymentMethodId", "Name");
+        ViewData["PaymentMethodId"] = new SelectList(_paymentMethods.GetActivePaymentMethods(), "PaymentMethodId", "Name");
         ViewData["UserId"] = new SelectList(_context.ApplicationUsers, "Id", "Id");
             return Page();
         }

--- a/src/EventManagement.Web/Pages/Admin/Registrations/Create.cshtml.cs
+++ b/src/EventManagement.Web/Pages/Admin/Registrations/Create.cshtml.cs
@@ -25,7 +25,7 @@ namespace losol.EventManagement.Pages.Admin.Registrations
         public IActionResult OnGet()
         {
         ViewData["EventInfoId"] = new SelectList(_context.EventInfos, "EventInfoId", "Code");
-        ViewData["PaymentMethodId"] = new SelectList(_paymentMethods.GetActivePaymentMethods(), "PaymentMethodId", "Name");
+        ViewData["PaymentMethod"] = new SelectList(_paymentMethods.GetActivePaymentMethods(), "Provider", "Name");
         ViewData["UserId"] = new SelectList(_context.ApplicationUsers, "Id", "Id");
             return Page();
         }

--- a/src/EventManagement.Web/Pages/Admin/Registrations/Delete.cshtml
+++ b/src/EventManagement.Web/Pages/Admin/Registrations/Delete.cshtml
@@ -119,7 +119,7 @@
             @Html.DisplayNameFor(model => model.Registration.PaymentMethod)
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Registration.PaymentMethod.Name)
+            @Html.DisplayFor(model => model.Registration.PaymentMethod)
         </dd>
         <dt>
             @Html.DisplayNameFor(model => model.Registration.User)
@@ -128,7 +128,7 @@
             @Html.DisplayFor(model => model.Registration.User.Id)
         </dd>
     </dl>
-    
+
     <form method="post">
         <input type="hidden" asp-for="Registration.RegistrationId" />
         <input type="submit" value="Delete" class="btn btn-default" /> |

--- a/src/EventManagement.Web/Pages/Admin/Registrations/Delete.cshtml.cs
+++ b/src/EventManagement.Web/Pages/Admin/Registrations/Delete.cshtml.cs
@@ -31,7 +31,6 @@ namespace losol.EventManagement.Pages.Admin.Registrations
 
             Registration = await _context.Registrations
                 .Include(r => r.EventInfo)
-                .Include(r => r.PaymentMethod)
                 .Include(r => r.User).SingleOrDefaultAsync(m => m.RegistrationId == id);
 
             if (Registration == null)

--- a/src/EventManagement.Web/Pages/Admin/Registrations/Details.cshtml
+++ b/src/EventManagement.Web/Pages/Admin/Registrations/Details.cshtml
@@ -118,7 +118,7 @@
         <li>Kursbevis: @Model.Registration.Certificate</li>
         <li>Brukerid: @Model.Registration.UserId</li>
         <li>Gratis? @Model.Registration.FreeRegistration</li>
-        <li>Betalingsmetode @Model.Registration.PaymentMethod.Name </li>
+        <li>Betalingsmetode @Model.Registration.PaymentMethod </li>
     </ul>
 </div>
 

--- a/src/EventManagement.Web/Pages/Admin/Registrations/Details.cshtml
+++ b/src/EventManagement.Web/Pages/Admin/Registrations/Details.cshtml
@@ -11,12 +11,12 @@
 
         <div class="clearfix">
             <div class="mr-3 float-left">
-                Status: 
+                Status:
                 <select asp-for="Registration.Status" asp-items="Html.GetEnumSelectList<Registration.RegistrationStatus>()">
                 </select>
             </div>
             <div class="mr-3 float-left">
-                Type deltaker: 
+                Type deltaker:
                 <select asp-for="Registration.Type" asp-items="Html.GetEnumSelectList<Registration.RegistrationType>()">
                 </select>
             </div>
@@ -44,7 +44,7 @@
                         @Html.DisplayFor(model => model.Registration.ParticipantJobTitle)
                     </div>
                     <br />
-                    
+
                     <small>Sted</small>
                     <div contenteditable="true" class="participantinfo" id="participant-city">
                         @Html.DisplayFor(model => model.Registration.ParticipantCity)
@@ -73,7 +73,7 @@
                         @Html.DisplayFor(model => model.Registration.CustomerEmail)
                     </div>
                     <br />
-                    
+
                     <small>Org.nr</small>
                     <div contenteditable="true" class="customerinfo" id="customer-vatnumber">
                         @Html.DisplayFor(model => model.Registration.CustomerVatNumber)
@@ -87,12 +87,12 @@
                     <br />
 
                     <small>Betalingsmetode</small><br />
-                    <select asp-for="Registration.PaymentMethodId">
+                    <select asp-for="Registration.PaymentMethod">
                         @foreach(var paymethod in Model.PaymentMethods) {
-                            <option value="@paymethod.PaymentMethodId">@paymethod.Name</option>
+                            <option value="@paymethod.Provider">@paymethod.Name</option>
                         }
                     </select>
-              
+
                 </div>
             </div>
         </div>
@@ -122,7 +122,7 @@
     </ul>
 </div>
 
-@section scripts { 
+@section scripts {
 <script>
     // *******PARTICIPANT INFO SCRIPTS *******
     // Add change listener to all contenteditables
@@ -222,9 +222,9 @@
 
 
     // ******* PAYMENTMETHOD UPDATE  SCRIPTS *******
-    $('#Registration_PaymentMethodId').on('change', function() {
-        var paymentMethodId = $("option:selected", this).val();
-        $.postJSON('/api/v0/registrations/@Model.Registration.RegistrationId/paymentmethod/update/' + paymentMethodId, null)
+    $('#Registration_PaymentMethod').on('change', function() {
+        var paymentMethod = $("option:selected", this).val();
+        $.postJSON('/api/v0/registrations/@Model.Registration.RegistrationId/paymentmethod/update/' + paymentMethod, null)
             .done(function() {
                 toastr.success('Lagret status');
             })
@@ -234,6 +234,6 @@
             });
     })
 
-        
+
 </script>
 }

--- a/src/EventManagement.Web/Pages/Admin/Registrations/Details.cshtml.cs
+++ b/src/EventManagement.Web/Pages/Admin/Registrations/Details.cshtml.cs
@@ -7,16 +7,19 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using losol.EventManagement.Domain;
 using losol.EventManagement.Infrastructure;
+using losol.EventManagement.Services;
 
 namespace losol.EventManagement.Pages.Admin.Registrations
 {
     public class DetailsModel : PageModel
     {
         private readonly ApplicationDbContext _context;
+        private readonly IPaymentMethodService _paymentMethods;
 
-        public DetailsModel(ApplicationDbContext context)
+        public DetailsModel(ApplicationDbContext context, IPaymentMethodService paymentMethods)
         {
             _context = context;
+            _paymentMethods = paymentMethods;
         }
 
         public Registration Registration { get; set; }
@@ -35,9 +38,7 @@ namespace losol.EventManagement.Pages.Admin.Registrations
                 .Include(r => r.Orders)
                 .Include(r => r.User).SingleOrDefaultAsync(m => m.RegistrationId == id);
 
-            PaymentMethods = await _context.PaymentMethods
-                .Where (m => m.Active == true)
-                .ToListAsync();
+            PaymentMethods = _paymentMethods.GetActivePaymentMethods();
 
             if (Registration == null)
             {

--- a/src/EventManagement.Web/Pages/Admin/Registrations/Details.cshtml.cs
+++ b/src/EventManagement.Web/Pages/Admin/Registrations/Details.cshtml.cs
@@ -34,7 +34,6 @@ namespace losol.EventManagement.Pages.Admin.Registrations
 
             Registration = await _context.Registrations
                 .Include(r => r.EventInfo)
-                .Include(r => r.PaymentMethod)
                 .Include(r => r.Orders)
                 .Include(r => r.User).SingleOrDefaultAsync(m => m.RegistrationId == id);
 

--- a/src/EventManagement.Web/Pages/Admin/Registrations/Edit.cshtml
+++ b/src/EventManagement.Web/Pages/Admin/Registrations/Edit.cshtml
@@ -93,9 +93,9 @@
                     <span asp-validation-for="Registration.Log" class="text-danger"></span>
                 </div>
                 <div class="form-group">
-                    <label asp-for="Registration.PaymentMethodId" class="control-label"></label>
-                    <select asp-for="Registration.PaymentMethodId" class="form-control" asp-items="ViewBag.PaymentMethodId"></select>
-                    <span asp-validation-for="Registration.PaymentMethodId" class="text-danger"></span>
+                    <label asp-for="Registration.PaymentMethod" class="control-label"></label>
+                    <select asp-for="Registration.PaymentMethod" class="form-control" asp-items="ViewBag.PaymentMethod"></select>
+                    <span asp-validation-for="Registration.PaymentMethod" class="text-danger"></span>
                 </div>
                 <div class="form-group">
                     <input type="submit" value="Save" class="btn btn-default" />

--- a/src/EventManagement.Web/Pages/Admin/Registrations/Edit.cshtml.cs
+++ b/src/EventManagement.Web/Pages/Admin/Registrations/Edit.cshtml.cs
@@ -44,7 +44,7 @@ namespace losol.EventManagement.Pages.Admin.Registrations
                 return NotFound();
             }
            ViewData["EventInfoId"] = new SelectList(_context.EventInfos, "EventInfoId", "Code");
-           ViewData["PaymentMethodId"] = new SelectList(_paymentMethods.GetActivePaymentMethods(), "PaymentMethodId", "Name");
+           ViewData["PaymentMethod"] = new SelectList(_paymentMethods.GetActivePaymentMethods(), "Provider", "Name");
            ViewData["UserId"] = new SelectList(_context.ApplicationUsers, "Id", "Id");
             return Page();
         }

--- a/src/EventManagement.Web/Pages/Admin/Registrations/Edit.cshtml.cs
+++ b/src/EventManagement.Web/Pages/Admin/Registrations/Edit.cshtml.cs
@@ -35,7 +35,6 @@ namespace losol.EventManagement.Pages.Admin.Registrations
 
             Registration = await _context.Registrations
                 .Include(r => r.EventInfo)
-                .Include(r => r.PaymentMethod)
                 .Include(r => r.User)
                 .SingleOrDefaultAsync(m => m.RegistrationId == id);
 

--- a/src/EventManagement.Web/Pages/Admin/Registrations/Edit.cshtml.cs
+++ b/src/EventManagement.Web/Pages/Admin/Registrations/Edit.cshtml.cs
@@ -8,16 +8,19 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using losol.EventManagement.Domain;
 using losol.EventManagement.Infrastructure;
+using losol.EventManagement.Services;
 
 namespace losol.EventManagement.Pages.Admin.Registrations
 {
     public class EditModel : PageModel
     {
         private readonly ApplicationDbContext _context;
+        private readonly IPaymentMethodService _paymentMethods;
 
-        public EditModel(ApplicationDbContext context)
+        public EditModel(ApplicationDbContext context, IPaymentMethodService paymentMethods)
         {
             _context = context;
+            _paymentMethods = paymentMethods;
         }
 
         [BindProperty]
@@ -41,7 +44,7 @@ namespace losol.EventManagement.Pages.Admin.Registrations
                 return NotFound();
             }
            ViewData["EventInfoId"] = new SelectList(_context.EventInfos, "EventInfoId", "Code");
-           ViewData["PaymentMethodId"] = new SelectList(_context.PaymentMethods, "PaymentMethodId", "Name");
+           ViewData["PaymentMethodId"] = new SelectList(_paymentMethods.GetActivePaymentMethods(), "PaymentMethodId", "Name");
            ViewData["UserId"] = new SelectList(_context.ApplicationUsers, "Id", "Id");
             return Page();
         }

--- a/src/EventManagement.Web/Pages/Admin/Registrations/Index.cshtml.cs
+++ b/src/EventManagement.Web/Pages/Admin/Registrations/Index.cshtml.cs
@@ -25,7 +25,6 @@ namespace losol.EventManagement.Pages.Admin.Registrations
         {
             Registrations = await _context.Registrations
                 .Include(r => r.EventInfo)
-                .Include(r => r.PaymentMethod)
                 .Include(r => r.User).ToListAsync();
         }
     }

--- a/src/EventManagement.Web/Pages/Events/Register/Index.cshtml
+++ b/src/EventManagement.Web/Pages/Events/Register/Index.cshtml
@@ -1,20 +1,21 @@
 ﻿@page "{id:int}"
 @model losol.EventManagement.Web.Pages.Events.Register.EventRegistrationModel
+@using static losol.EventManagement.Domain.PaymentMethod;
 @{
     ViewData["Title"] = Model.EventInfo.Title + "- Påmelding";
-    
+
     Layout = "~/Pages/_Layout.cshtml";
 }
 <div class="container">
 <h1 class="display-2 pt-5">@Model.EventInfo.Title - p&aring;melding</h1>
 <p class="lead">@Model.EventInfo.Description</p>
 <p><a asp-page="../Details" asp-route-id="@Model.Registration.EventInfoId" class="btn  my-3 btn btn-info link-decoration-none">Se program og mer informasjon</a>  </p>
-    
+
 <div asp-validation-summary="ModelOnly" class="text-danger"></div>
 
 <form method="post">
     <div class="row justify-content-between py-3">
-        <div class="col-md-9"> 
+        <div class="col-md-9">
             <div class="form-group">
                 <label asp-for="Registration.ParticipantName"></label>
                 <input asp-for="Registration.ParticipantName" class="form-control" />
@@ -61,16 +62,16 @@
 
             @* START PAYMENT  *@
             @if (Model.EventInfo.Products.Any()) {
-            <div id="payment py-5" > 
+            <div id="payment py-5" >
                 <div class="form-group"><!-- Payment method -->
-                    <label asp-for="Registration.PaymentMethodId"></label><br>
+                    <label asp-for="Registration.PaymentMethod"></label><br>
                     <div>
                     @foreach (var item in Model.PaymentMethods)
                     {
-                        <label class="radio-inline pr-3">  
-                        <input asp-for="Registration.PaymentMethodId" id="Registration_PaymentMethodId_@item.PaymentMethodId" type="radio" value="@item.PaymentMethodId" onclick="paymentMethod()"/> @item.Name  
+                        <label class="radio-inline pr-3">
+                        <input asp-for="Registration.PaymentMethod" id="Registration_PaymentMethod_@item.Provider" type="radio" value="@item.Provider" onclick="paymentMethod()"/> @item.Name
                         </label>
-                
+
                     }
                     </div>
                 </div>
@@ -104,7 +105,7 @@
             </div>
             }
 
-            
+
             @if(Model.Products.Any()){
                 <h4 class="pt-5 pb-3">Tilpass bestillingen</h4>
                 @for(int i = 0; i < Model.Products.Count; i++)
@@ -163,7 +164,7 @@
                 }
             }
 
-         
+
 
             <div class="form-group py-3">
                 <input type="submit" value="Registrer meg" class="btn btn-lg btn-success" />
@@ -178,9 +179,9 @@
 <script>
 
     function paymentMethod() {
-        if (document.getElementById('Registration_PaymentMethodId_3').checked) {
+        if (document.getElementById('Registration_PaymentMethod_@PaymentProvider.PowerOfficeEHFInvoice').checked) {
             $('#customerdetails').collapse('show');
-        };   
+        };
     }
 </script>
 @section Scripts {

--- a/src/EventManagement.Web/Pages/Events/Register/Index.cshtml.cs
+++ b/src/EventManagement.Web/Pages/Events/Register/Index.cshtml.cs
@@ -15,6 +15,7 @@ using losol.EventManagement.ViewModels;
 using losol.EventManagement.Web.Services;
 using losol.EventManagement.Services.Extensions;
 using System.Text;
+using static losol.EventManagement.Domain.PaymentMethod;
 
 namespace losol.EventManagement.Web.Pages.Events.Register
 {
@@ -49,7 +50,7 @@ namespace losol.EventManagement.Web.Pages.Events.Register
 		public EventInfo EventInfo { get; set; }
 		public List<PaymentMethod> PaymentMethods { get; set; }
 		public List<Product> Products => EventInfo.Products;
-		public int DefaultPaymentMethod => _paymentMethodService.GetDefaultPaymentMethodId();
+		public PaymentProvider DefaultPaymentMethod => _paymentMethodService.GetDefaultPaymentMethod().Provider;
 
 		public async Task<IActionResult> OnGetAsync(int id)
 		{

--- a/src/EventManagement.Web/Pages/Events/Register/Index.cshtml.cs
+++ b/src/EventManagement.Web/Pages/Events/Register/Index.cshtml.cs
@@ -61,7 +61,7 @@ namespace losol.EventManagement.Web.Pages.Events.Register
 				return NotFound();
 			}
 
-			PaymentMethods = await _paymentMethodService.GetActivePaymentMethodsAsync();
+			PaymentMethods = _paymentMethodService.GetActivePaymentMethods();
 			Registration = new RegisterVM(EventInfo, DefaultPaymentMethod);
 
 			return Page();
@@ -72,7 +72,7 @@ namespace losol.EventManagement.Web.Pages.Events.Register
 
 			if (!ModelState.IsValid)
 			{
-				PaymentMethods = await _paymentMethodService.GetActivePaymentMethodsAsync();
+				PaymentMethods = _paymentMethodService.GetActivePaymentMethods();
 				return Page();
 			}
 
@@ -114,7 +114,7 @@ namespace losol.EventManagement.Web.Pages.Events.Register
 					{
 						ModelState.AddModelError(string.Empty, error.Description);
 					}
-					PaymentMethods = await _paymentMethodService.GetActivePaymentMethodsAsync();
+					PaymentMethods = _paymentMethodService.GetActivePaymentMethods();
 					return Page();
 				}
 			}

--- a/src/EventManagement.Web/Pages/Events/Register/RegisterVM.cs
+++ b/src/EventManagement.Web/Pages/Events/Register/RegisterVM.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using losol.EventManagement.Domain;
 using losol.EventManagement.Services;
+using static losol.EventManagement.Domain.PaymentMethod;
 using static losol.EventManagement.Domain.Registration;
 
 namespace losol.EventManagement.Web.Pages.Events.Register
@@ -59,7 +60,7 @@ namespace losol.EventManagement.Web.Pages.Events.Register
 		public string CustomerInvoiceReference { get; set; }
 
 		[Display(Name = "Betaling")]
-		public int? PaymentMethodId { get; set; }
+		public PaymentProvider? PaymentMethod { get; set; }
 
 		public ProductVM[] Products { get; set; }
 
@@ -67,10 +68,10 @@ namespace losol.EventManagement.Web.Pages.Events.Register
 		public RegistrationType Type { get; set; } = RegistrationType.Participant;
 
 		public RegisterVM() { }
-		public RegisterVM(EventInfo eventinfo, int? defaultPaymentMethod = null)
+		public RegisterVM(EventInfo eventinfo, PaymentProvider? defaultPaymentMethod = null)
 		{
 			EventInfoId = eventinfo.EventInfoId;
-			PaymentMethodId = defaultPaymentMethod;
+			PaymentMethod = defaultPaymentMethod;
 
 			Products = new ProductVM[eventinfo.Products.Count];
 			for (int i = 0; i < Products.Length; i++)

--- a/src/EventManagement.Web/Program.cs
+++ b/src/EventManagement.Web/Program.cs
@@ -15,9 +15,9 @@ using Microsoft.Extensions.Logging;
 namespace losol.EventManagement
 {
     public class Program
-    { 
+    {
         public static async Task Main(string[] args)
-        { 
+        {
             // Build the application host
             var host = BuildWebHost(args);
 
@@ -34,6 +34,9 @@ namespace losol.EventManagement
 
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration(app => {
+                    app.AddJsonFile("paymentproviders.json", optional: true, reloadOnChange: false);
+                })
                 .UseStartup<Startup>()
                 .Build();
     }

--- a/src/EventManagement.Web/Startup.cs
+++ b/src/EventManagement.Web/Startup.cs
@@ -23,6 +23,7 @@ using losol.EventManagement.Services.PowerOffice;
 using losol.EventManagement.Config;
 using losol.EventManagement.Web.Config;
 using losol.EventManagement.Web.Extensions;
+using System.Collections.Generic;
 
 namespace losol.EventManagement
 {
@@ -158,6 +159,7 @@ namespace losol.EventManagement
 
 			// Register our application services
 			services.AddScoped<IEventInfoService, EventInfoService>();
+            services.Configure<List<PaymentMethod>>(Configuration.GetSection("PaymentMethods"));
 			services.AddScoped<IPaymentMethodService, PaymentMethodService>();
 			services.AddScoped<IRegistrationService, RegistrationService>();
 			services.AddScoped<IProductsService, ProductsService>();

--- a/src/EventManagement.Web/Startup.cs
+++ b/src/EventManagement.Web/Startup.cs
@@ -47,6 +47,9 @@ namespace losol.EventManagement
               options.EnableSensitiveDataLogging(HostingEnvironment.IsDevelopment());
             });
 
+
+                // sqlite: options.UseSqlite(Configuration.GetConnectionString("DefaultConnection"))); 
+
             services.AddIdentity<ApplicationUser, IdentityRole>(config =>
             {
                 config.SignIn.RequireConfirmedEmail = true;
@@ -54,6 +57,18 @@ namespace losol.EventManagement
                 .AddEntityFrameworkStores<ApplicationDbContext>()
                 .AddDefaultTokenProviders()
                 .AddMagicLinkTokenProvider();
+
+            // Require SSL
+            // TODO Re-enable
+            /* if (HostingEnvironment.IsProduction())
+            {
+                services.Configure<MvcOptions>(options =>
+                {
+                    options.Filters.Add(new RequireHttpsAttribute());
+                });
+            }
+            */
+            
 
             // Set password requirements
             services.Configure<IdentityOptions>(options =>
@@ -70,18 +85,18 @@ namespace losol.EventManagement
             CultureInfo.DefaultThreadCurrentCulture = cultureInfo;
             CultureInfo.DefaultThreadCurrentUICulture = cultureInfo;
 
-
+            
             services.AddAuthorization(options =>
             {
                 options.AddPolicy("AdministratorRole", policy => policy.RequireRole("Admin", "SuperAdmin"));
             });
-
+            
             services.AddMvc()
                 .AddRazorPagesOptions(options =>
                 {
                     options.Conventions.AuthorizeFolder("/Account/Manage");
                     options.Conventions.AuthorizePage("/Account/Logout");
-
+                    
                     options.Conventions.AuthorizeFolder("/Admin", "AdministratorRole");
                     options.Conventions.AddPageRoute("/Events/Details", "events/{id}/{slug?}");
 
@@ -89,6 +104,9 @@ namespace losol.EventManagement
 
                     options.Conventions.AddPageRoute("/Events/Register/Index", "events/{id}/{slug?}/register");
                 });
+
+            // For sending antiforgery in ajax?
+            // services.AddAntiforgery(o => o.HeaderName = "XSRF-TOKEN");
 
             // Register the Database Seed initializer & email sender services
             services.Configure<DbInitializerOptions>(Configuration);
@@ -155,7 +173,7 @@ namespace losol.EventManagement
             {
                 services.AddTransient<IInvoicingService, MockInvoicingService>();
             }
-
+            
 
 			// Register our application services
 			services.AddScoped<IEventInfoService, EventInfoService>();
@@ -169,6 +187,7 @@ namespace losol.EventManagement
 
             // Add Page render Service
             services.AddScoped<IRenderService, ViewRenderService>();
+
 
             // Added for the renderpage service
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
@@ -196,7 +215,17 @@ namespace losol.EventManagement
             }
 
             app.UseStaticFiles();
+
             app.UseAuthentication();
+
+            // TODO reenable
+            /*
+            if (env.IsProduction()) {
+                var options = new RewriteOptions()
+                .AddRedirectToHttps(); 
+                app.UseRewriter(options);
+            }
+             */
 
             app.UseMvc(routes =>
             {

--- a/src/EventManagement.Web/Startup.cs
+++ b/src/EventManagement.Web/Startup.cs
@@ -46,9 +46,6 @@ namespace losol.EventManagement
               options.EnableSensitiveDataLogging(HostingEnvironment.IsDevelopment());
             });
 
-
-                // sqlite: options.UseSqlite(Configuration.GetConnectionString("DefaultConnection"))); 
-
             services.AddIdentity<ApplicationUser, IdentityRole>(config =>
             {
                 config.SignIn.RequireConfirmedEmail = true;
@@ -56,18 +53,6 @@ namespace losol.EventManagement
                 .AddEntityFrameworkStores<ApplicationDbContext>()
                 .AddDefaultTokenProviders()
                 .AddMagicLinkTokenProvider();
-
-            // Require SSL
-            // TODO Re-enable
-            /* if (HostingEnvironment.IsProduction())
-            {
-                services.Configure<MvcOptions>(options =>
-                {
-                    options.Filters.Add(new RequireHttpsAttribute());
-                });
-            }
-            */
-            
 
             // Set password requirements
             services.Configure<IdentityOptions>(options =>
@@ -84,18 +69,18 @@ namespace losol.EventManagement
             CultureInfo.DefaultThreadCurrentCulture = cultureInfo;
             CultureInfo.DefaultThreadCurrentUICulture = cultureInfo;
 
-            
+
             services.AddAuthorization(options =>
             {
                 options.AddPolicy("AdministratorRole", policy => policy.RequireRole("Admin", "SuperAdmin"));
             });
-            
+
             services.AddMvc()
                 .AddRazorPagesOptions(options =>
                 {
                     options.Conventions.AuthorizeFolder("/Account/Manage");
                     options.Conventions.AuthorizePage("/Account/Logout");
-                    
+
                     options.Conventions.AuthorizeFolder("/Admin", "AdministratorRole");
                     options.Conventions.AddPageRoute("/Events/Details", "events/{id}/{slug?}");
 
@@ -103,9 +88,6 @@ namespace losol.EventManagement
 
                     options.Conventions.AddPageRoute("/Events/Register/Index", "events/{id}/{slug?}/register");
                 });
-
-            // For sending antiforgery in ajax?
-            // services.AddAntiforgery(o => o.HeaderName = "XSRF-TOKEN");
 
             // Register the Database Seed initializer & email sender services
             services.Configure<DbInitializerOptions>(Configuration);
@@ -172,7 +154,7 @@ namespace losol.EventManagement
             {
                 services.AddTransient<IInvoicingService, MockInvoicingService>();
             }
-            
+
 
 			// Register our application services
 			services.AddScoped<IEventInfoService, EventInfoService>();
@@ -185,7 +167,6 @@ namespace losol.EventManagement
 
             // Add Page render Service
             services.AddScoped<IRenderService, ViewRenderService>();
-
 
             // Added for the renderpage service
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
@@ -213,17 +194,7 @@ namespace losol.EventManagement
             }
 
             app.UseStaticFiles();
-
             app.UseAuthentication();
-
-            // TODO reenable
-            /*
-            if (env.IsProduction()) {
-                var options = new RewriteOptions()
-                .AddRedirectToHttps(); 
-                app.UseRewriter(options);
-            }
-             */
 
             app.UseMvc(routes =>
             {

--- a/src/EventManagement.Web/paymentproviders.json
+++ b/src/EventManagement.Web/paymentproviders.json
@@ -1,0 +1,40 @@
+{
+  "PaymentMethods": [
+    {
+      "PaymentMethodId": 2,
+      "Name": "PowerOfficeEmailInvoice",
+      "Provider": "PowerOfficeEmailInvoice",
+      "Active": true,
+      "AdminOnly": false,
+      "IsDefault": true
+    },
+    {
+      "PaymentMethodId": 3,
+      "Name": "PowerOfficeEHFInvoice",
+      "Provider": "PowerOfficeEHFInvoice",
+      "Active": true,
+      "AdminOnly": false
+    },
+    {
+      "PaymentMethodId": 10,
+      "Name": "EmailInvoice",
+      "Provider": "EmailInvoice",
+      "Active": false,
+      "AdminOnly": false
+    },
+    {
+      "PaymentMethodId": 11,
+      "Name": "Stripe",
+      "Provider": "Stripe",
+      "Active": false,
+      "AdminOnly": false
+    },
+    {
+      "PaymentMethodId": 12,
+      "Name": "Vipps",
+      "Provider": "Vipps",
+      "Active": false,
+      "AdminOnly": false
+    }
+  ]
+}

--- a/tests/EventManagement.IntegrationTests/Fixtures/TestFixture.cs
+++ b/tests/EventManagement.IntegrationTests/Fixtures/TestFixture.cs
@@ -26,7 +26,11 @@ namespace losol.EventManagement.IntegrationTests.Fixtures
 			var builder = new WebHostBuilder()
 				.UseContentRoot("../../../../../src/EventManagement.Web")
 				.UseEnvironment("Development")
-				.ConfigureAppConfiguration((b, c) => c.AddJsonFile("appsettings.json"))
+				.ConfigureAppConfiguration((b, c) =>
+                {
+                    c.AddJsonFile("appsettings.json");
+                    c.AddJsonFile("paymentproviders.json");
+                })
 				.UseStartup<TestStartup>()
 				.ConfigureServices(ConfigureServices);
 

--- a/tests/EventManagement.IntegrationTests/paymentproviders.json
+++ b/tests/EventManagement.IntegrationTests/paymentproviders.json
@@ -1,0 +1,19 @@
+{
+  "PaymentMethods": [
+    {
+      "PaymentMethodId": 2,
+      "Name": "PowerOfficeEmailInvoice",
+      "Provider": "PowerOfficeEmailInvoice",
+      "Active": true,
+      "AdminOnly": false,
+      "IsDefault": true
+    },
+    {
+      "PaymentMethodId": 3,
+      "Name": "PowerOfficeEHFInvoice",
+      "Provider": "PowerOfficeEHFInvoice",
+      "Active": true,
+      "AdminOnly": false
+    }
+  ]
+}


### PR DESCRIPTION
Once this has been merged, the following script must be run:

```sql
UPDATE Registrations
    SET PaymentMethod = PaymentMethodId
    WHERE PaymentMethod is null
GO

UPDATE Orders
    SET PaymentMethod = PaymentMethodId
    WHERE PaymentMethod is null
GO
```

Following which the `PaymentMethodId` fields can be removed from the `Registrations` and `Orders` tables.