### PR TITLE
Stripe integration for Invoices

### DIFF
--- a/docs/Setup/Configuration.md
+++ b/docs/Setup/Configuration.md
@@ -7,7 +7,8 @@ The JSON structure defines the configuration for the application.
   "AppSettings": {
     "EmailProvider": "SendGrid|SMTP|File|Mock",
     "SmsProvider": "Twilio|Mock",
-    "UsePowerOffice": "false|true"
+    "UsePowerOffice": "false|true",
+    "UseStripe": "false|true"
   },
   "Logging": {
     "IncludeScopes": false,
@@ -45,6 +46,10 @@ The JSON structure defines the configuration for the application.
     "ClientKey": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     "Mode": "Production|Test|Beta|Demo|Debug",
     "TokenStoreName": "name.tokenstore"
+  },
+  "Stripe": {
+    "SecretKey": "sk_test_BQokikJOvBiI2HlWgH4olfQ2",
+    "PublishableKey": "pk_test_6pRNASCoBOKtIshFeQd4XMUh"
   }
 }
 ```

--- a/src/EventManagement.Services/EventManagement.Services.csproj
+++ b/src/EventManagement.Services/EventManagement.Services.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="MailKit" Version="2.0.1" />
     <PackageReference Include="PowerOfficeGoSdk" Version="2.0.4" />
     <PackageReference Include="Sendgrid" Version="9.9.0" />
+    <PackageReference Include="Stripe.net" Version="16.1.0" />
     <PackageReference Include="Twilio" Version="5.10.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/EventManagement.Services/Invoicing/IInvoicingService.cs
+++ b/src/EventManagement.Services/Invoicing/IInvoicingService.cs
@@ -1,7 +1,7 @@
 using System.Threading.Tasks;
 using losol.EventManagement.Domain;
 
-namespace losol.EventManagement.Services.PowerOffice
+namespace losol.EventManagement.Services.Invoicing
 {
     public interface IInvoicingService
     {

--- a/src/EventManagement.Services/Invoicing/MockInvoicingService.cs
+++ b/src/EventManagement.Services/Invoicing/MockInvoicingService.cs
@@ -1,7 +1,7 @@
 using System.Threading.Tasks;
 using losol.EventManagement.Domain;
 
-namespace losol.EventManagement.Services.PowerOffice
+namespace losol.EventManagement.Services.Invoicing
 {
     public class MockInvoicingService : IInvoicingService
     {

--- a/src/EventManagement.Services/Invoicing/PowerOfficeOptions.cs
+++ b/src/EventManagement.Services/Invoicing/PowerOfficeOptions.cs
@@ -1,6 +1,6 @@
 using static GoApi.Global.Settings;
 
-namespace losol.EventManagement.Services.PowerOffice
+namespace losol.EventManagement.Services.Invoicing
 {
     public class PowerOfficeOptions
     {

--- a/src/EventManagement.Services/Invoicing/PowerOfficeService.cs
+++ b/src/EventManagement.Services/Invoicing/PowerOfficeService.cs
@@ -12,7 +12,7 @@ using losol.EventManagement.Infrastructure;
 using Microsoft.Extensions.Options;
 using static losol.EventManagement.Domain.PaymentMethod;
 
-namespace losol.EventManagement.Services.PowerOffice {
+namespace losol.EventManagement.Services.Invoicing {
     public class PowerOfficeService : IInvoicingService {
 
         private readonly Go api;

--- a/src/EventManagement.Services/Invoicing/StripeInvoicingService.cs
+++ b/src/EventManagement.Services/Invoicing/StripeInvoicingService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using losol.EventManagement.Domain;
@@ -25,10 +26,11 @@ namespace losol.EventManagement.Services.Invoicing
                 var invoiceLineItem = await service.CreateAsync(createInvoiceLineOptions);
             }
 
+            var eventInfo = order.Registration.EventInfo;
             var createInvoiceOptions = new StripeInvoiceCreateOptions
             {
                 Billing = StripeBilling.SendInvoice,
-                DaysUntilDue = 30,
+                DaysUntilDue = eventInfo.DateStart.HasValue ? ((eventInfo.LastCancellationDate ?? eventInfo.LastRegistrationDate ?? eventInfo.DateStart) - DateTime.UtcNow).Value.Days : 30,
                 Description = $"Deltakelse for {order.Registration.ParticipantName} på {order.Registration.EventInfo.Title} "
             };
             var createInvoiceService = new StripeInvoiceService();

--- a/src/EventManagement.Services/Invoicing/StripeInvoicingService.cs
+++ b/src/EventManagement.Services/Invoicing/StripeInvoicingService.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+using losol.EventManagement.Domain;
+
+namespace losol.EventManagement.Services.Invoicing
+{
+    public class StripeInvoicingService : IInvoicingService
+    {
+        public Task CreateInvoiceAsync(Order order)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/src/EventManagement.Services/Invoicing/StripeInvoicingService.cs
+++ b/src/EventManagement.Services/Invoicing/StripeInvoicingService.cs
@@ -1,13 +1,66 @@
+using System.Linq;
 using System.Threading.Tasks;
 using losol.EventManagement.Domain;
+using Microsoft.Extensions.Options;
+using Stripe;
 
 namespace losol.EventManagement.Services.Invoicing
 {
     public class StripeInvoicingService : IInvoicingService
     {
-        public Task CreateInvoiceAsync(Order order)
+        public async Task CreateInvoiceAsync(Order order)
         {
-            throw new System.NotImplementedException();
+            var customer = await getOrCreateCustomer(order);
+            var service = new StripeInvoiceItemService();
+
+            foreach(var line in order.OrderLines)
+            {
+                var createInvoiceLineOptions = new StripeInvoiceItemCreateOptions
+                {
+                    Amount = (int)(line.TotalAmount * 100m), // inclusive of quantity & tax
+                    Currency = "nok", // TODO: read this from config
+                    CustomerId = customer.Id,
+                    Description = !string.IsNullOrWhiteSpace(line.ProductVariantName) ? $"{line.ProductName} ({line.ProductVariantName})" : line.ProductName,
+                };
+                var invoiceLineItem = await service.CreateAsync(createInvoiceLineOptions);
+            }
+
+            var createInvoiceOptions = new StripeInvoiceCreateOptions
+            {
+                Billing = StripeBilling.SendInvoice,
+                DaysUntilDue = 30,
+                Description = $"Deltakelse for {order.Registration.ParticipantName} på {order.Registration.EventInfo.Title} "
+            };
+            var createInvoiceService = new StripeInvoiceService();
+            await createInvoiceService.CreateAsync(customer.Id, createInvoiceOptions);
+        }
+
+        private async Task<StripeCustomer> getOrCreateCustomer(Order order)
+        {
+
+            var service = new StripeCustomerService();
+            var listOptions = new StripeCustomerListOptions
+            {
+                Limit = 1
+            };
+            listOptions.AddExtraParam("email", order.CustomerEmail);
+            var customer = (await service.ListAsync(listOptions)).Data.FirstOrDefault();
+            if (customer != null) return customer;
+
+            var customerCreateOptions = new StripeCustomerCreateOptions
+            {
+                Email = order.CustomerEmail,
+                BusinessVatId = order.CustomerVatNumber
+            };
+            return await service.CreateAsync(customerCreateOptions);
+        }
+
+        /// <summary>
+        /// Call this once before using the StripeInvoicingService
+        /// </summary>
+        public static void Configure(string secretKey)
+        {
+            StripeConfiguration.SetApiKey(secretKey);
         }
     }
 }

--- a/src/EventManagement.Services/Invoicing/StripeOptions.cs
+++ b/src/EventManagement.Services/Invoicing/StripeOptions.cs
@@ -1,0 +1,8 @@
+namespace losol.EventManagement.Services.Invoicing
+{
+    public class StripeOptions
+    {
+        public string SecretKey { get; set; }
+        public string PublishableKey { get; set; }
+    }
+}

--- a/src/EventManagement.Services/MessageLogService.cs
+++ b/src/EventManagement.Services/MessageLogService.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using losol.EventManagement.Domain;
 using losol.EventManagement.Infrastructure;
-using losol.EventManagement.Services.PowerOffice;
 using Microsoft.EntityFrameworkCore;
 using static losol.EventManagement.Domain.Order;
 
@@ -18,8 +17,8 @@ namespace losol.EventManagement.Services {
 
 		public async Task<bool> AddAsync(int eventinfoId, string recipients, string messageContent, string messageType, string provider = "", string result = "") {
 			var entry = new MessageLog() {
-				EventInfoId = eventinfoId, 
-				Recipients = recipients, 
+				EventInfoId = eventinfoId,
+				Recipients = recipients,
 				MessageContent = messageContent,
 				MessageType = messageType,
 				Provider = provider,

--- a/src/EventManagement.Services/OrderService.cs
+++ b/src/EventManagement.Services/OrderService.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using losol.EventManagement.Domain;
 using losol.EventManagement.Infrastructure;
-using losol.EventManagement.Services.PowerOffice;
+using losol.EventManagement.Services.Invoicing;
 using Microsoft.EntityFrameworkCore;
 using static losol.EventManagement.Domain.Order;
 

--- a/src/EventManagement.Web/Config/AppSettings.cs
+++ b/src/EventManagement.Web/Config/AppSettings.cs
@@ -6,9 +6,10 @@ namespace losol.EventManagement.Config
 		public EmailProvider EmailProvider { get; set; }
 		public SmsProvider SmsProvider { get; set; }
 		public bool UsePowerOffice { get; set; }
+        public bool UseStripe { get; set; }
 	}
 
-	internal enum EmailProvider 
+	internal enum EmailProvider
 	{
 		SendGrid,
 		SMTP,

--- a/src/EventManagement.Web/Startup.cs
+++ b/src/EventManagement.Web/Startup.cs
@@ -169,11 +169,12 @@ namespace losol.EventManagement
                 services.Configure<PowerOfficeOptions>(Configuration.GetSection("PowerOffice"));
                 services.AddScoped<IInvoicingService, PowerOfficeService>();
             }
-            else if(appsettings.UseStripe)
+            if(appsettings.UseStripe)
             {
                 // STRIPE OVERRIDES POWEROFFICE
-                // THIS NEEDS TO BE DOCUMENTED OR CHANGED
-                services.Configure<StripeOptions>(Configuration.GetSection("Stripe"));
+                // THIS NEEDS TO BE CHANGED
+                var config = Configuration.GetSection("Stripe").Get<StripeOptions>();
+                StripeInvoicingService.Configure(config.SecretKey);
                 services.AddScoped<IInvoicingService, StripeInvoicingService>();
             }
             else

--- a/src/EventManagement.Web/Startup.cs
+++ b/src/EventManagement.Web/Startup.cs
@@ -169,6 +169,13 @@ namespace losol.EventManagement
                 services.Configure<PowerOfficeOptions>(Configuration.GetSection("PowerOffice"));
                 services.AddScoped<IInvoicingService, PowerOfficeService>();
             }
+            else if(appsettings.UseStripe)
+            {
+                // STRIPE OVERRIDES POWEROFFICE
+                // THIS NEEDS TO BE DOCUMENTED OR CHANGED
+                services.Configure<StripeOptions>(Configuration.GetSection("Stripe"));
+                services.AddScoped<IInvoicingService, StripeInvoicingService>();
+            }
             else
             {
                 services.AddTransient<IInvoicingService, MockInvoicingService>();

--- a/src/EventManagement.Web/Startup.cs
+++ b/src/EventManagement.Web/Startup.cs
@@ -19,7 +19,7 @@ using losol.EventManagement.Services.DbInitializers;
 using losol.EventManagement.Services.Messaging;
 using losol.EventManagement.Web.Services;
 using losol.EventManagement.Services.Messaging.Sms;
-using losol.EventManagement.Services.PowerOffice;
+using losol.EventManagement.Services.Invoicing;
 using losol.EventManagement.Config;
 using losol.EventManagement.Web.Config;
 using losol.EventManagement.Web.Extensions;
@@ -48,7 +48,7 @@ namespace losol.EventManagement
             });
 
 
-                // sqlite: options.UseSqlite(Configuration.GetConnectionString("DefaultConnection"))); 
+                // sqlite: options.UseSqlite(Configuration.GetConnectionString("DefaultConnection")));
 
             services.AddIdentity<ApplicationUser, IdentityRole>(config =>
             {
@@ -68,7 +68,7 @@ namespace losol.EventManagement
                 });
             }
             */
-            
+
 
             // Set password requirements
             services.Configure<IdentityOptions>(options =>
@@ -85,18 +85,18 @@ namespace losol.EventManagement
             CultureInfo.DefaultThreadCurrentCulture = cultureInfo;
             CultureInfo.DefaultThreadCurrentUICulture = cultureInfo;
 
-            
+
             services.AddAuthorization(options =>
             {
                 options.AddPolicy("AdministratorRole", policy => policy.RequireRole("Admin", "SuperAdmin"));
             });
-            
+
             services.AddMvc()
                 .AddRazorPagesOptions(options =>
                 {
                     options.Conventions.AuthorizeFolder("/Account/Manage");
                     options.Conventions.AuthorizePage("/Account/Logout");
-                    
+
                     options.Conventions.AuthorizeFolder("/Admin", "AdministratorRole");
                     options.Conventions.AddPageRoute("/Events/Details", "events/{id}/{slug?}");
 
@@ -173,7 +173,7 @@ namespace losol.EventManagement
             {
                 services.AddTransient<IInvoicingService, MockInvoicingService>();
             }
-            
+
 
 			// Register our application services
 			services.AddScoped<IEventInfoService, EventInfoService>();
@@ -222,7 +222,7 @@ namespace losol.EventManagement
             /*
             if (env.IsProduction()) {
                 var options = new RewriteOptions()
-                .AddRedirectToHttps(); 
+                .AddRedirectToHttps();
                 app.UseRewriter(options);
             }
              */


### PR DESCRIPTION
Enable this feature by setting `AppSettings.UseStripe` to `true` in the configuration. Note that it overrides the PowerOffice Invoicing with Stripe's Invoicing if both are enabled.