### PR TITLE
Do not add items with 0 quantities

### DIFF
--- a/src/EventManagement.Domain/Registration.cs
+++ b/src/EventManagement.Domain/Registration.cs
@@ -272,7 +272,7 @@ namespace losol.EventManagement.Domain
                     }
                     var product = products.Find(p => p.Product.ProductId == order.Product.ProductId);
                     var orderline = order.ToOrderLine();
-                    if(product != null && product.Variant?.ProductVariantId != order.Variant?.ProductVariantId)
+                    if(product != null && product.Variant?.ProductVariantId != order.Variant?.ProductVariantId) // if a product variant is being replaced
                     {
                         lines.Add(orderline);
                         var refundLine = product.ToOrderLine();
@@ -282,7 +282,10 @@ namespace losol.EventManagement.Domain
                     else
                     {
                         orderline.Quantity = order.Quantity - (product?.Quantity ?? 0);
-                        lines.Add(orderline);
+                        if(orderline.Quantity != 0)
+                        {
+                            lines.Add(orderline);
+                        }
                     }
                 }
             }

--- a/tests/EventManagement.UnitTests/RegistrationTests/Create_Or_Update_Order_Should.cs
+++ b/tests/EventManagement.UnitTests/RegistrationTests/Create_Or_Update_Order_Should.cs
@@ -397,5 +397,41 @@ namespace losol.EventManagement.UnitTests.RegistrationTests
             Assert.Equal(3, last.Count);
         }
 
+
+        [Fact]
+        public void Not_Add_Items_With_Zero_Quantity()
+        {
+            // Arrange
+            var registration = new Registration()
+            {
+                Orders = new List<Order>
+                {
+                    new Order
+                    {
+                        OrderLines = new List<OrderLine>
+                        {
+                            Helpers.GetOrderLine(productId: 1, price: 1000, quantity: 1),
+                            Helpers.GetOrderLine(productId: 2, price: 1000, quantity: 0)
+                        }
+                    }
+                }
+            };
+            var orderitems = new List<OrderDTO>
+            {
+                Helpers.GetOrderDto(productId: 1, price: 1000, quantity: 1),
+                Helpers.GetOrderDto(productId: 2, price: 1000, quantity: 0),
+                Helpers.GetOrderDto(productId: 3, price: 1000, quantity: 0),
+                Helpers.GetOrderDto(productId: 4, price: 1000, quantity: 0),
+            };
+
+            // Act
+            registration.CreateOrUpdateOrder(orderitems);
+            var lines = registration.Orders.First().OrderLines;
+
+            //Assert
+            Assert.Single(lines);
+            Assert.Equal(1000, registration.Orders.Sum(o => o.TotalAmount));
+        }
+
     }
 }


### PR DESCRIPTION
Fixed Bug: Adding items with 0 quantity when an editable order exists, causes 0 quantity orderlines to be added to the order.