### PR TITLE
Add depends clause to docker-compose

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -12,11 +12,11 @@ services:
       - AppSettings__SmsProvider=Mock
     ports:
       - "5100:80"
+    depends_on:
+      - mssql
 
   mssql:
     environment:
       - MSSQL_SA_PASSWORD=Passw0rd!
       - ACCEPT_EULA=Y
       - MSSQL_PID=Developer
-    ports:
-      - "6433:1433"


### PR DESCRIPTION
* Add a depends clause
* Remove unnecessary port arguments for mssql

This PR should ensure the application starts only after mssql is ready when running `docker-compose up`