### PR TITLE
Remove obsolete PaymentMethodId fields

### DIFF
--- a/src/EventManagement.Domain/Order.cs
+++ b/src/EventManagement.Domain/Order.cs
@@ -75,7 +75,6 @@ namespace losol.EventManagement.Domain
 		public string CustomerEmail { get; set; }
 		public string CustomerVatNumber { get; set; }
 		public string CustomerInvoiceReference { get; set; }
-		public int? PaymentMethodId { get; set; }
         public PaymentProvider? PaymentMethod { get; set; }
 
 		public DateTime OrderTime { get; set; } = DateTime.UtcNow;

--- a/src/EventManagement.Domain/Order.cs
+++ b/src/EventManagement.Domain/Order.cs
@@ -75,7 +75,7 @@ namespace losol.EventManagement.Domain
 		public string CustomerEmail { get; set; }
 		public string CustomerVatNumber { get; set; }
 		public string CustomerInvoiceReference { get; set; }
-        public PaymentProvider? PaymentMethod { get; set; }
+        public PaymentProvider PaymentMethod { get; set; }
 
 		public DateTime OrderTime { get; set; } = DateTime.UtcNow;
 

--- a/src/EventManagement.Domain/Registration.cs
+++ b/src/EventManagement.Domain/Registration.cs
@@ -74,7 +74,6 @@ namespace losol.EventManagement.Domain
 
         [Display(Name = "Betalingsmetode")]
         public PaymentProvider? PaymentMethod { get; set; }
-        public int? PaymentMethodId { get; set; }
 
         [Display(Name = "Verifisert påmelding?")]
         public bool Verified { get; set; } = false;
@@ -89,7 +88,7 @@ namespace losol.EventManagement.Domain
         // Navigation properties
         public EventInfo EventInfo { get; set; }
         public ApplicationUser User { get; set; }
-        // public PaymentMethod PaymentMethod { get; set; }
+
         public List<Order> Orders { get; set; }
 
         [NotMapped]

--- a/src/EventManagement.Domain/Registration.cs
+++ b/src/EventManagement.Domain/Registration.cs
@@ -73,7 +73,7 @@ namespace losol.EventManagement.Domain
         public bool FreeRegistration { get; set; } = false;
 
         [Display(Name = "Betalingsmetode")]
-        public PaymentProvider? PaymentMethod { get; set; }
+        public PaymentProvider PaymentMethod { get; set; } = PaymentProvider.PowerOfficeEmailInvoice; // HACK: This ignores the actual default paymentmethod set in the database
 
         [Display(Name = "Verifisert påmelding?")]
         public bool Verified { get; set; } = false;

--- a/src/EventManagement.Infrastructure/Migrations/20180828121549_RemoveObsoletePaymentMethodIdFields.Designer.cs
+++ b/src/EventManagement.Infrastructure/Migrations/20180828121549_RemoveObsoletePaymentMethodIdFields.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using losol.EventManagement.Infrastructure;
 
 namespace losol.EventManagement.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20180828121549_RemoveObsoletePaymentMethodIdFields")]
+    partial class RemoveObsoletePaymentMethodIdFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/EventManagement.Infrastructure/Migrations/20180828121549_RemoveObsoletePaymentMethodIdFields.cs
+++ b/src/EventManagement.Infrastructure/Migrations/20180828121549_RemoveObsoletePaymentMethodIdFields.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace losol.EventManagement.Infrastructure.Migrations
+{
+    public partial class RemoveObsoletePaymentMethodIdFields : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PaymentMethodId",
+                table: "Registrations");
+
+            migrationBuilder.DropColumn(
+                name: "PaymentMethodId",
+                table: "Orders");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "PaymentMethodId",
+                table: "Registrations",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PaymentMethodId",
+                table: "Orders",
+                nullable: true);
+        }
+    }
+}

--- a/src/EventManagement.Infrastructure/Migrations/20180828124033_AddNotNullConstraintToPaymentMethodFields.Designer.cs
+++ b/src/EventManagement.Infrastructure/Migrations/20180828124033_AddNotNullConstraintToPaymentMethodFields.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using losol.EventManagement.Infrastructure;
 
 namespace losol.EventManagement.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20180828124033_AddNotNullConstraintToPaymentMethodFields")]
+    partial class AddNotNullConstraintToPaymentMethodFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/EventManagement.Infrastructure/Migrations/20180828124033_AddNotNullConstraintToPaymentMethodFields.cs
+++ b/src/EventManagement.Infrastructure/Migrations/20180828124033_AddNotNullConstraintToPaymentMethodFields.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace losol.EventManagement.Infrastructure.Migrations
+{
+    public partial class AddNotNullConstraintToPaymentMethodFields : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "PaymentMethod",
+                table: "Registrations",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "PaymentMethod",
+                table: "Orders",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "PaymentMethod",
+                table: "Registrations",
+                nullable: true,
+                oldClrType: typeof(int));
+
+            migrationBuilder.AlterColumn<int>(
+                name: "PaymentMethod",
+                table: "Orders",
+                nullable: true,
+                oldClrType: typeof(int));
+        }
+    }
+}

--- a/src/EventManagement.Services/OrderService.cs
+++ b/src/EventManagement.Services/OrderService.cs
@@ -192,15 +192,11 @@ namespace losol.EventManagement.Services {
 				.Include (o => o.Registration)
 				.ThenInclude (r => r.EventInfo)
 				.SingleOrDefaultAsync (o => o.OrderId == orderId);
-			
-			if (!order.PaymentMethodId.HasValue) {
-				_logger.LogError($"OrderId {order.Status} has no PaymentMethodId.");
-				throw new InvalidOperationException($"OrderId {order.PaymentMethodId} has no PaymentMethodId. Order status: {order.Status}.");
-			}
-			_logger.LogInformation($"Making invoice for order: {order.OrderId}, paymenmethodId: {order.PaymentMethodId}");
-			
+
+			_logger.LogInformation($"Making invoice for order: {order.OrderId}, paymenmethod: {order.PaymentMethod}");
+
 			bool invoiceCreated = false;
-			
+
 			if (order.PaymentMethod == PaymentProvider.PowerOfficeEHFInvoice || order.PaymentMethod == PaymentProvider.PowerOfficeEmailInvoice) {
 				_logger.LogInformation("* Using PowerOffice for invoicing");
 				invoiceCreated = await _powerOfficeService.CreateInvoiceAsync (order);
@@ -213,7 +209,7 @@ namespace losol.EventManagement.Services {
 				order.MarkAsInvoiced ();
 				_db.Orders.Update (order);
 				await _db.SaveChangesAsync ();
-			}	
+			}
 			return  invoiceCreated;
 		}
 

--- a/src/EventManagement.Services/RegistrationService.cs
+++ b/src/EventManagement.Services/RegistrationService.cs
@@ -210,11 +210,6 @@ namespace losol.EventManagement.Services {
 			// Create/update an order as needed.
 			registration.CreateOrUpdateOrder(await Task.WhenAll(ordersDto));
 
-			// Set paymentmethod to default method if null.
-			if (registration.PaymentMethod == null) {
-				registration.PaymentMethod = _paymentMethods.GetDefaultPaymentProvider();
-			}
-
 			// Persist the changes
 			return await _db.SaveChangesAsync () > 0;
 		}


### PR DESCRIPTION
Run this query first before merging:

```SQL
UPDATE Registrations
    SET PaymentMethod = COALESCE(PaymentMethodId, 2)
    WHERE PaymentMethod is null
GO

UPDATE Orders
    SET PaymentMethod = COALESCE(PaymentMethodId, 2)
    WHERE PaymentMethod is null
GO
```

Closes #279 
Closes #278